### PR TITLE
Close events channel after job completes

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -133,6 +133,11 @@ end:
 		err = ctx.Err()
 	}
 
+	// close events channel to signal that we're done here
+	if events != nil {
+		close(events)
+	}
+
 	// send the result
 	resultChan <- result{success, err}
 }


### PR DESCRIPTION
In order to avoid that listeners are waiting for more events after the job has completed we have to close the channel.