### PR TITLE
Make output of labelSelector determinisitic

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 	"time"
 
@@ -192,8 +193,16 @@ func streamLogsForContainer(cs *kubernetes.Clientset, pod *core.Pod, container s
 // labelSelector converts a label map (as used in the job spec) into a label query as used in the API.
 func labelSelector(labels map[string]string) string {
 	var buf bytes.Buffer
-	for k, v := range labels {
-		fmt.Fprintf(&buf, "%s=%s,", k, v)
+
+	// sort keys to make output deterministic
+	var keys []string
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		fmt.Fprintf(&buf, "%s=%s,", k, labels[k])
 	}
 	if buf.Len() > 0 {
 		buf.Truncate(buf.Len() - 1)

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -17,7 +17,7 @@ func TestLabelSelector(t *testing.T) {
 		},
 		{
 			map[string]string{"foo": "bar", "fizz": "buzz"},
-			"foo=bar,fizz=buzz",
+			"fizz=buzz,foo=bar",
 		},
 	}
 


### PR DESCRIPTION
Iterating over a map in Go is random. Therefore we have to manually sort the keys if we want deterministic output.